### PR TITLE
Use `String.upcase/1` in linq9 example

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,7 +436,7 @@ public void Linq9()
 test "linq9: Select - Anonymous Types 1" do
   words = ["aPPLE", "BlUeBeRrY", "cHeRry"]
 
-  upper_lower_words = words |> Enum.map(fn x -> %{lower: String.downcase(x), upper: String.capitalize(x)} end)
+  upper_lower_words = words |> Enum.map(fn x -> %{lower: String.downcase(x), upper: String.upcase(x)} end)
 
   for n <- upper_lower_words, do: IO.puts "Uppercase: #{n.upper}, Lowercase: #{n.lower}" end
 end

--- a/test/projection_test.exs
+++ b/test/projection_test.exs
@@ -39,7 +39,7 @@ defmodule ElixirLinqExamples.Projection do
   test "linq9: Select - Anonymous Types 1" do
     words = ["aPPLE", "BlUeBeRrY", "cHeRry"]
 
-    upper_lower_words = words |> Enum.map(fn x -> %{lower: String.downcase(x), upper: String.capitalize(x)} end)
+    upper_lower_words = words |> Enum.map(fn x -> %{lower: String.downcase(x), upper: String.upcase(x)} end)
 
     # for n <- upper_lower_words, do: IO.puts "Uppercase: #{n.upper}, Lowercase: #{n.lower}" end
   end


### PR DESCRIPTION
All characters in string are uppercase not only first one
